### PR TITLE
Revert "Increase tests to 50"

### DIFF
--- a/runA11yTests.js
+++ b/runA11yTests.js
@@ -57,7 +57,7 @@ async function getTestPromises( tests, config, browser ) {
 	process.setMaxListeners( 10 );
 
 	// Limit to 100 tests. Any more and pixel.wmcloud freezes up.
-	return tests.slice(0, 50).map( async ( test ) => {
+	return tests.slice(0, 30).map( async ( test ) => {
 		const { url, name, ...testOptions } = test;
 		const page = await browser.newPage();
 		const testConfig = { ...options, ...testOptions, browser, page };


### PR DESCRIPTION
Leads to timeout errors on pixel instance.

This reverts commit 2e2bc239ef5532571640f7f2bc05cce58b58a08e.