### PR TITLE
Add screenshots and more detailed error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const { runAccessibilityChecksForURLs } = require( './modules/accessibility.test
 
 // Main function to run the application
 async function main( options ) {
+	console.time( 'Application ran successfully.' );
 	try {
 		// Run accessibility checks and generate reports
 		await runAccessibilityChecksForURLs( options.project,
@@ -14,7 +15,7 @@ async function main( options ) {
 			options.alpha
 		);
 
-		console.log( 'Application ran successfully.' );
+		console.timeEnd( 'Application ran successfully.' );
 	} catch ( error ) {
 		console.error( 'An error occurred:', error );
 	}

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ async function main( options ) {
 		await runAccessibilityChecksForURLs( options.project,
 			options.query, options.mobile, options.source, options.limit,
 			parseInt( options.zleep, 10 ),
-			options.alpha
+			options.alpha,
+			options.includeScreenshots
 		);
 
 		console.timeEnd( 'Application ran successfully.' );
@@ -60,8 +61,13 @@ const alphaOpt = [
 	'Forces the addition of alpha styles from the beta cluster.'
 ];
 
+const screenshotOpt = [
+	'-s, --include-screenshots',
+	'Capture screenshots of errors and add them to the report.'
+];
+
 program
-	.description( 'Welcome to the pixel CLI to perform visual regression testing' )
+	.description( 'Welcome to the Night mode checker CLI to perform color contrast testing' )
 	.option( ...projectOpt )
 	.option( ...queryOpt )
 	.option( ...mobileOpt )
@@ -69,6 +75,7 @@ program
 	.option( ...limitOpt )
 	.option( ...sleepOpt )
 	.option( ...alphaOpt )
+	.option( ...screenshotOpt )
 	.requiredOption( ...projectOpt )
 	.action( async ( opts ) => {
 		main( opts );

--- a/modules/accessibility.test.js
+++ b/modules/accessibility.test.js
@@ -42,7 +42,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null, title, in
 
 	const checkContrast = async ( type, title ) => {
 		// Run axe on the page
-		console.time('	Axe ran successfully:');
+		console.time(`	Axe ran successfully for page ${title}:`);
 		const results = await page.evaluate( () => {
 			axe.cleanup();
 			return axe.run( {
@@ -52,7 +52,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null, title, in
 				}
 			} );
 		} );
-		console.timeEnd('	Axe ran successfully:');
+		console.timeEnd(`	Axe ran successfully for page ${title}:`);
 		// Filter violations based on id
 		const colorContrastViolation = results.violations.find(
 			violation => violation.id === 'color-contrast'

--- a/modules/accessibility.test.js
+++ b/modules/accessibility.test.js
@@ -26,7 +26,7 @@ async function newPage( browser, url ) {
 async function runAccessibilityCheck( browser, url, stylesheet = null ) {
 	let page;
 	const pending = setInterval(() => {
-		console.log(`Still checking contrast on ${url}`);
+		console.log(`	⏳ Still checking contrast on ${url}`);
 	}, 5000);
 
 	try {
@@ -42,7 +42,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null ) {
 
 	const checkContrast = async ( type ) => {
 		// Run axe on the page
-		console.time('Total Axe run time: ');
+		console.time('	Axe ran successfully:');
 		const results = await page.evaluate( () => {
 			axe.cleanup();
 			return axe.run( {
@@ -52,8 +52,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null ) {
 				}
 			} );
 		} );
-		console.error( `Axe ran successfully.` );
-		console.timeEnd('Total Axe run time: ');
+		console.timeEnd('	Axe ran successfully:');
 		// Filter violations based on id
 		const colorContrastViolation = results.violations.find(
 			violation => violation.id === 'color-contrast'
@@ -80,19 +79,19 @@ async function runAccessibilityCheck( browser, url, stylesheet = null ) {
 			);
 
 			clearTimeout( pending );
-			console.error( `Color contrast violation found on ${url} (${type}).` );
+			console.error( `	✖️ Color contrast violation found on ${url} (${type}).` );
 			// Return the array of nodeDetails if it exists
 			return nodeDetailsArray.length > 0 ? nodeDetailsArray : null;
 		} else {
 			clearTimeout( pending );
-			console.log( `No color contrast violation found on ${url} (${type}).` );
+			console.log( `	\x1b[32m✔️ No color contrast violation found on ${url} (${type}).\x1b[0m` );
 			return false;
 		}
 	};
 	let result = [];
 	try {
 		pagesScanned++;
-		console.log(`Checking standard theme...${pagesScanned}`);
+		console.log(`	🌞 Checking standard theme...${pagesScanned}`);
 		const day = await checkContrast( 'default' );
 		if ( day === false ) {
 			noColorContrastViolationCount++;
@@ -103,7 +102,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null ) {
 			document.documentElement.classList.remove( 'skin-theme-clientpref-day', 'skin-theme-clientpref--excluded' );
 			document.documentElement.classList.add('skin-theme-clientpref-night')
 		} );
-		console.log(`Checking dark theme...${pagesScanned}`);
+		console.log(`	🌚 Checking dark theme...${pagesScanned}`);
 		const night = await checkContrast( 'dark' );
 		if ( night === false ) {
 			noColorContrastViolationCountDark++;
@@ -180,7 +179,7 @@ async function runAccessibilityChecksForURLs( project, query, mobile, source, li
 					title: testCase.title,
 				} ) );
 
-				console.log( `Result for URL ${testCase.article}:`, {
+				console.log( `Result for URL ${testCase.title}:`, {
 					simplifiedList,
 					colorContrastErrorNum: simplifiedList ? simplifiedList.length : 0,
 				} );

--- a/modules/accessibility.test.js
+++ b/modules/accessibility.test.js
@@ -97,6 +97,7 @@ async function runAccessibilityCheck( browser, url, stylesheet = null, title ) {
 						selector,
 						title: title,
 						type: type,
+						failureSummary: node.failureSummary,
 						screenshot: ( node.screenshot ) ? node.screenshot.replace( '../report/', '') : null
 					};
 				} )
@@ -198,11 +199,11 @@ async function runAccessibilityChecksForURLs( project, query, mobile, source, li
 				const simplifiedList = result.map( node => ( {
 					selector: node.selector,
 					context: node.context,
-					// Drop querystring from domain in favor of override.
-					pageUrl: `${testCase.url.split('?')[0].replace('.m.', '.')}${queryOverride}`,
+					pageUrl: `${testCase.url}${queryOverride}`,
 					title: testCase.title,
 					type: node.type,
-					screenshot: node.screenshot
+					screenshot: node.screenshot,
+					message: node.failureSummary
 				} ) );
 
 				console.log( `Result for URL ${testCase.title}:`, {

--- a/modules/htmlGenerator.js
+++ b/modules/htmlGenerator.js
@@ -7,7 +7,7 @@ function escapeHTML( text ) {
 	return text.replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 }
 
-function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned, mobile, type ) {
+function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned ) {
 	try {
 		// Read the template file.
 		const templatePath = path.join( __dirname, '../views/template.mustache' );
@@ -26,8 +26,9 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 		const tableSections = Object.keys( groupedItems ).map( pageUrl => {
 			const items = groupedItems[pageUrl].map( item => `
 				<tr>
-					<td>${item.selector}</td>
-					<td>${escapeHTML( item.context )}</td>
+					<td><pre>${item.selector}</pre></td>
+					<td><pre>${escapeHTML( item.context )}</pre></td>
+					<td>${item.message}</td>
 					<td><img src="${item.screenshot}"/></td>
 				</tr>
 			`).join( '' );
@@ -41,6 +42,7 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 						<tr>
 							<th>Selector</th>
 							<th>Context</th>
+							<th>Message</th>
 							<th>Screenshot</th>
 						</tr>
 					</thead>

--- a/modules/htmlGenerator.js
+++ b/modules/htmlGenerator.js
@@ -7,7 +7,7 @@ function escapeHTML( text ) {
 	return text.replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 }
 
-function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned ) {
+function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned, includeScreenshots ) {
 	try {
 		// Read the template file.
 		const templatePath = path.join( __dirname, '../views/template.mustache' );
@@ -29,7 +29,7 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 					<td><pre>${item.selector}</pre></td>
 					<td><pre>${escapeHTML( item.context )}</pre></td>
 					<td>${item.message}</td>
-					<td><img src="${item.screenshot}"/></td>
+					${ includeScreenshots ? `<td><img src="${item.screenshot}"/></td>` : '' }
 				</tr>
 			`).join( '' );
 			const totalItemsForPageUrl = groupedItems[pageUrl].length;
@@ -43,7 +43,7 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 							<th>Selector</th>
 							<th>Context</th>
 							<th>Message</th>
-							<th>Screenshot</th>
+							${ includeScreenshots ? `<th>Screenshot</th>` : '' }
 						</tr>
 					</thead>
 					<tbody>

--- a/modules/htmlGenerator.js
+++ b/modules/htmlGenerator.js
@@ -7,7 +7,7 @@ function escapeHTML( text ) {
 	return text.replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 }
 
-function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned ) {
+function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount, colorContrastViolationCount, pagesScanned, mobile, type ) {
 	try {
 		// Read the template file.
 		const templatePath = path.join( __dirname, '../views/template.mustache' );
@@ -28,6 +28,7 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 				<tr>
 					<td>${item.selector}</td>
 					<td>${escapeHTML( item.context )}</td>
+					<td><img src="${item.screenshot}"/></td>
 				</tr>
 			`).join( '' );
 			const totalItemsForPageUrl = groupedItems[pageUrl].length;
@@ -40,6 +41,7 @@ function generateHTMLPage( file, simplifiedLists, noColorContrastViolationCount,
 						<tr>
 							<th>Selector</th>
 							<th>Context</th>
+							<th>Screenshot</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/views/template.mustache
+++ b/views/template.mustache
@@ -23,6 +23,7 @@
 			display: none;
 			width: 100%;
 			border-collapse: collapse;
+			table-layout: fixed;
 		}
 
 		th,

--- a/views/template.mustache
+++ b/views/template.mustache
@@ -37,6 +37,11 @@
 			background-color: #f2f2f2;
 		}
 
+		pre {
+			white-space: wrap;
+			word-break: break-word;
+		}
+
 		.collapsible {
 			cursor: pointer;
 			border-bottom: 1px solid gray;padding-bottom: 1.5rem;


### PR DESCRIPTION
Adds screenshots and detailed error messages for the contrast report.
The screenshots are organized the following folder structure: report/{domain name}/{page title}{error index}.png
Note, the screenshot commit reverts a change where the `m.` URL was removed from the report links (not sure what the reason for that was). 