### PR TITLE
Scan top "first" to "first+limit" pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,10 @@ The web team use the following query to decide whether a project is ready for da
 ```
 node index.js --project 'xx.projectname' -m --limit 500 --zleep 1500 --source pageviews-main
 ```
+#### Partial runs
+Sometimes the above process hangs. Try using partial runs with a longer delay. The following query will scan from top 100th to top 150th page, and sleep for 10 seconds before starting a new scan.
+```
+node index.js --project 'xx.projectname' -m --first 100 --limit 50 --zleep 10000 --source pageviews-main
+```
 ### Important Note
 This tool is currently in development and should be used cautiously. Stay tuned for updates and improvements!

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ async function main( options ) {
 	try {
 		// Run accessibility checks and generate reports
 		await runAccessibilityChecksForURLs( options.project,
-			options.query, options.mobile, options.source, options.limit,
+			options.query, options.mobile, options.source,
+			parseInt( options.first, 10 ), parseInt( options.limit, 10 ),
 			parseInt( options.zleep, 10 ),
 			options.alpha,
 			options.includeScreenshots
@@ -44,6 +45,11 @@ const sourceOpt = [
 	'pageviews'
 ];
 
+const firstOpt = [
+	'-f, --first <query>',
+	'Index of the last page for the subset of pages.'
+];
+
 const limitOpt = [
 	'-l, --limit <query>',
 	'Default: 100',
@@ -72,6 +78,7 @@ program
 	.option( ...queryOpt )
 	.option( ...mobileOpt )
 	.option( ...sourceOpt )
+	.option( ...firstOpt )
 	.option( ...limitOpt )
 	.option( ...sleepOpt )
 	.option( ...alphaOpt )

--- a/modules/accessibility.test.js
+++ b/modules/accessibility.test.js
@@ -183,8 +183,8 @@ function sleep( time ) {
 	} );
 }
 
-async function runAccessibilityChecksForURLs( project, query, mobile, source, limit, sleepDuration = 5000, addBetaClusterStyles = false, includeScreenshots = false ) {
-	const testCases = await createTestCases( { project, query, mobile, source, limit } );
+async function runAccessibilityChecksForURLs( project, query, mobile, source, first, limit, sleepDuration = 5000, addBetaClusterStyles = false, includeScreenshots = false ) {
+	const testCases = await createTestCases( { project, query, mobile, source, first, limit } );
 
 	// Run accessibility checks for each URL concurrently
 	const browser = await puppeteer.launch( {

--- a/modules/topArticles.js
+++ b/modules/topArticles.js
@@ -38,7 +38,6 @@ async function getTopWikipediaArticles( project, first=0, limit = 1, mainNSOnly 
 			const articles = data.items[0].articles
 				.filter( ( a ) => !EXCLUDE_LIST.includes( a.article ) )
 				.filter( ( a ) => mainNSOnly ? a.article.indexOf( ':' ) === -1 : true ).slice( first, first+limit );
-			console.log("HERE",first, first+limit)
 			return articles.map( ( a ) => Object.assign( {}, a, {
 				project: `https://${project}.org`
 			} ) );


### PR DESCRIPTION
Scan of the top 500 pages usually hangs due to memory leaks. Introduce a new option to scan --limit top pages starting from --first. 