### PR TITLE
default value for --first

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ const sourceOpt = [
 
 const firstOpt = [
 	'-f, --first <query>',
-	'Index of the last page for the subset of pages.'
+	'Default: 0',
+	'0'
 ];
 
 const limitOpt = [


### PR DESCRIPTION
previously copied from the wrong old option (apologies!); this sets the default value of --first to 0